### PR TITLE
Fix: Static asset loading issues on OAuth callback

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -52,5 +52,5 @@
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6"
   },
-  "homepage": "."
+  "homepage": "/"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -11,8 +11,35 @@
   ],
   "routes": [
     {
+      "src": "/static/(.*)",
+      "dest": "/static/$1"
+    },
+    {
+      "src": "/favicon.ico",
+      "dest": "/favicon.ico"
+    },
+    {
+      "src": "/manifest.json",
+      "dest": "/manifest.json"
+    },
+    {
+      "src": "/auth/google/callback",
+      "dest": "/index.html"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Update Vercel configuration to properly handle static assets
- Fix homepage path in package.json from '.' to '/'
- Add specific route for /auth/google/callback
- Add proper static asset routing and caching headers
- Resolves 404 errors for CSS/JS files on OAuth callback page